### PR TITLE
[PATCH] Change default method name from 'Destroy' to 'Disconnect'

### DIFF
--- a/Template/ReplicatedStorage/Packages/Shared/Utility/Janitor.lua
+++ b/Template/ReplicatedStorage/Packages/Shared/Utility/Janitor.lua
@@ -90,7 +90,7 @@ function Janitor.__index:Add(Object, MethodName, Index)
 		end
 	end--]]
 
-	MethodName = MethodName or TypeDefaults[typeof(Object)] or "Destroy"
+	MethodName = MethodName or TypeDefaults[typeof(Object)] or "Disconnect"
 	if type(Object) ~= "function" and not Object[MethodName] then
 		warn(string.format(METHOD_NOT_FOUND_ERROR, tostring(Object), tostring(MethodName), debug.traceback(nil, 2)))
 	end


### PR DESCRIPTION
## Tipo de alteração

-   [x] 🐞 Correção de bug (sem quebra de compatibilidade)
-   [ ] ✨ Nova funcionalidade (adiciona algo sem quebrar nada existente)
-   [ ] ⚙️ Refatoração / Melhoria interna
-   [x] 🧩 Patch (correção ou ajuste pequeno em componente específico)
-   [ ] 🚀 Release (nova versão estável da Layre Org)
-   [ ] 📝 Documentação (atualização de docs ou comentários)

---

## Descrição

A versão atual do Janitor (que está na org na branch main) não permite omitir o parâmetro que especifica qual tipo de método usar ao criar alguma conexão/listener, por exemplo:
- Preciso dar :Connect() em um RBXScriptSignal
- `Janitor:Add(Signal:Connect(function() ...`
- Mas o janitor nos obriga a especificar 'Disconnect' (causa poluição de código)

Apenas alterei a linha 93 em Utility/Janitor para "Disconnect" ao invéz de "Destroy"

---

## Checklist de revisão

-   [x] Fiz _self-review_ do meu código
-   [x] Testei localmente no Roblox Studio (sem erros no output)
-   [x] Nenhum comportamento inesperado ao executar o plugin
-   [x] Código bem comentado em partes complexas
-   [x] Atualizei documentação ou changelog, se necessário
-   [x] PR vinculado à issue correspondente

---

## Observações sobre release

-   Tipo de versão: `patch`
-   Componentes afetados: `libs`
